### PR TITLE
fix when decorate('yellow', 0) is passed

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ module.exports = function filelog (taskParam) {
     return callback();
   }, function (cb) {
     var task = taskParam ? decorate('blue', taskParam) + ' ' : '';
-    gutil.log(task +  'Found ' + decorate('yellow', count) + ' files.');
+    gutil.log(task + 'Found ' + decorate('yellow', count.toString()) + ' files.');
     cb();
   });
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-filelog",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "A gulp plugin that logs out the file names in the stream. Displays a count and if empty. Useful for debugging.",
   "keywords": [
     "gulpplugin",


### PR DESCRIPTION
When running this task

``` js
gulp.task('minify-js', function () {
    ['store', 'global', 'digitalstore'].forEach(function(prop) {
        gulp.src('js/' + prop + '/build/*.js')
            .pipe(changed('js/' + prop, {
                extension: '.min.js'
            }))
            .pipe(filelog())
            .pipe(jshint())
            .pipe(jshint.reporter('default'))
            .pipe(uglify())
            .pipe(rename({suffix: '.min'}))
            .pipe(gulp.dest('js/' + prop))
    });
});
```

I see empty count statements for the properties w/o changed files:
![screen shot 2014-10-30 at 1 00 06 pm](https://cloud.githubusercontent.com/assets/3459542/4847913/3cf9cdbe-6056-11e4-828e-bc65047cf203.png)

This fix will ensure it displays correctly:
![screen shot 2014-10-30 at 1 00 53 pm](https://cloud.githubusercontent.com/assets/3459542/4847925/55db4a6a-6056-11e4-8edc-77e03946deb1.png)
