### PR TITLE
Pull all files with resume.

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ module.exports = function filelog (taskParam) {
     return text ? '[' + gutil.colors[color](text) + ']' : '';
   }
 
-  return through.obj(function (file, enc, callback) {
+  var stream = through.obj(function (file, enc, callback) {
     var items = [];
     count++;
 
@@ -34,4 +34,8 @@ module.exports = function filelog (taskParam) {
     gutil.log(task + 'Found ' + decorate('yellow', count.toString()) + ' files.');
     cb();
   });
+
+  stream.resume();
+
+  return stream;
 };


### PR DESCRIPTION
We need to use .resume to ensure we pull all files from stream and not only the first 16 files.

This is experienced when using file blobs which includes wildcards and finds more than 16 files.
