### PR TITLE
Show relative instead of absolute file paths

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 'use strict';
 
+var path = require('path');
 var through = require('through2');
 var gutil = require('gulp-util');
 
@@ -19,7 +20,7 @@ module.exports = function filelog (taskParam) {
     }
 
     items.push(decorate('yellow', count));
-    items.push(decorate('cyan', file.path));
+    items.push(decorate('cyan', path.relative(process.cwd(), file.path)));
 
     if (file.isNull()) {
       items.push(decorate('magenta', 'EMPTY'));


### PR DESCRIPTION
Instead of logging full `/long/path/to/project/directory/GOOD/PART/HERE` paths, just show the `GOOD/PART/HERE` part, i e changing output paths to look like this:

![gulp-filelog-relative](https://cloud.githubusercontent.com/assets/2459/9744865/3fa4d842-5623-11e5-802a-121b6486792a.png)
